### PR TITLE
fix: Update versions in child modules

### DIFF
--- a/actions/create-changelog-and-release/action.yml
+++ b/actions/create-changelog-and-release/action.yml
@@ -98,7 +98,6 @@ runs:
       run: |
         mvn $MAVEN_ARGS versions:set \
           -DnewVersion="$NEW_VERSION" \
-          -N versions:update-child-modules \
           -DgenerateBackupPoms=false
         mvn $MAVEN_ARGS versions:commit
 


### PR DESCRIPTION
ops-control-read-model uses child modules and requires version updates for them. See failed release https://github.com/CleverShuttle/ops-control-read-model/runs/5985912335?check_suite_focus=true